### PR TITLE
Prevent automatic dashboard redirect after signup

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,14 +1,11 @@
 import React from 'react';
-import { 
-  Mic, 
-  LogOut, 
-  BookOpen, 
-  TrendingUp, 
-  Clock, 
+import {
+  Mic,
+  LogOut,
+  BookOpen,
+  Clock,
   Star,
   Play,
-  BarChart3,
-  Calendar,
   Target,
   Award,
   MessageCircle


### PR DESCRIPTION
## Summary
- track signup attempts via `onSignUpStart`
- sign out newly registered users to show login modal instead of dashboard
- clean up unused icons and state for lint compliance

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895fba2bd70832a942905f85c7dfbc8