### PR TITLE
Refresh UI with modern palette and page transitions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,8 @@ function App() {
   const [openFAQ, setOpenFAQ] = useState<number | null>(null);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [currentTestimonial, setCurrentTestimonial] = useState(0);
+  const [pageLoaded, setPageLoaded] = useState(false);
+
   const signingUpRef = useRef(false);
 
   const benefits = [
@@ -249,11 +251,15 @@ function App() {
     setOpenFAQ(openFAQ === index ? null : index);
   };
 
+  useEffect(() => {
+    setPageLoaded(true);
+  }, []);
+
   if (loading) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-amber-50 to-orange-50 flex items-center justify-center">
+      <div className="min-h-screen bg-gradient-to-br from-secondary-50 to-primary-50 flex items-center justify-center">
         <div className="text-center">
-          <Mic className="h-12 w-12 text-orange-600 mx-auto mb-4 animate-pulse" />
+          <Mic className="h-12 w-12 text-primary-600 mx-auto mb-4 animate-pulse" />
           <p className="text-gray-600">Loading TalkBuddy...</p>
         </div>
       </div>
@@ -265,14 +271,14 @@ function App() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-amber-100 to-orange-100">
+    <div className={`min-h-screen bg-gradient-to-br from-secondary-100 to-primary-100 transition-opacity duration-700 ${pageLoaded ? 'opacity-100' : 'opacity-0'}`}> 
 
       {/* Header */}
-      <header className="relative z-50 bg-amber-50/95 backdrop-blur-sm border-b border-amber-300">
+      <header className="relative z-50 bg-secondary-50/95 backdrop-blur-sm border-b border-secondary-300">
         <div className="max-w-7xl mx-auto px-2 sm:px-4 lg:px-6">
           <div className="flex justify-between items-center py-4">
             <div className="flex items-center space-x-2">
-              <Mic className="h-8 w-8 text-orange-600" />
+              <Mic className="h-8 w-8 text-primary-600" />
               <span className="text-2xl font-bold text-gray-900">TalkBuddy</span>
             </div>
             
@@ -287,14 +293,14 @@ function App() {
             <div className="flex items-center space-x-4">
               <button 
                 onClick={() => handleAuthModal('login')}
-                className="hidden md:inline-flex px-6 py-2 bg-orange-600 text-white rounded-lg hover:bg-orange-700 transform hover:scale-105 transition-all duration-200 font-medium"
+                className="hidden md:inline-flex px-6 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transform hover:scale-105 transition-all duration-200 font-medium"
               >
                 Login
               </button>
 
               <button
                 onClick={() => setIsMenuOpen(!isMenuOpen)}
-                className="md:hidden p-2 rounded-lg bg-orange-100 hover:bg-orange-200 transition-colors"
+                className="md:hidden p-2 rounded-lg bg-primary-100 hover:bg-primary-200 transition-colors"
               >
                 {isMenuOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
               </button>
@@ -304,7 +310,7 @@ function App() {
 
         {/* Mobile Menu */}
         {isMenuOpen && (
-          <div className="md:hidden bg-amber-50 border-t border-orange-300">
+          <div className="md:hidden bg-secondary-50 border-t border-primary-300">
             <div className="px-2 py-2 space-y-2">
               <a href="#home" className="block py-2 text-gray-700 hover:text-blue-600">Home</a>
               <a href="#benefits" className="block py-2 text-gray-700 hover:text-blue-600">Benefits</a>
@@ -313,7 +319,7 @@ function App() {
               <a href="#faq" className="block py-2 text-gray-700 hover:text-blue-600">FAQ</a>
               <button 
                 onClick={() => handleAuthModal('login')}
-                className="w-full mt-2 px-6 py-2 bg-orange-600 text-white rounded-lg hover:bg-orange-700 transition-colors"
+                className="w-full mt-2 px-6 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors"
               >
                 Login
               </button>
@@ -323,12 +329,12 @@ function App() {
       </header>
 
       {/* Hero Section */}
-      <section id="home" className="relative overflow-hidden py-20 lg:py-28 bg-gradient-to-br from-amber-100 to-orange-100">
+      <section id="home" className="relative overflow-hidden py-20 lg:py-28 bg-gradient-to-br from-secondary-100 to-primary-100">
         <div className="max-w-7xl mx-auto px-2 sm:px-4 lg:px-6">
           <div className="grid lg:grid-cols-2 gap-12 items-center">
             <div className="space-y-8">
               <div className="space-y-4">
-                <p className="text-orange-600 font-medium uppercase tracking-wide">
+                <p className="text-primary-600 font-medium uppercase tracking-wide">
                   Introducing Your Personal AI Language Coach
                 </p>
                 <h1 className="text-4xl lg:text-6xl font-bold text-gray-900 leading-tight">
@@ -342,7 +348,7 @@ function App() {
               <div className="flex flex-col sm:flex-row gap-4">
                 <button 
                   onClick={() => handleAuthModal('signup')}
-                  className="px-8 py-4 bg-orange-600 text-white rounded-lg hover:bg-orange-700 transform hover:scale-105 transition-all duration-200 font-medium text-lg shadow-lg"
+                  className="px-8 py-4 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transform hover:scale-105 transition-all duration-200 font-medium text-lg shadow-lg"
                 >
                   Try Your First Conversation
                 </button>
@@ -358,8 +364,8 @@ function App() {
             </div>
 
             <div className="relative">
-              <div className="absolute inset-0 bg-gradient-to-r from-orange-200 to-orange-300 rounded-full transform scale-110 soft-glow"></div>
-              <div className="relative bg-cream-50 rounded-2xl p-8 shadow-2xl border border-orange-200">
+              <div className="absolute inset-0 bg-gradient-to-r from-primary-200 to-primary-300 rounded-full transform scale-110 soft-glow"></div>
+              <div className="relative bg-white rounded-2xl p-8 shadow-2xl border border-primary-200">
                 <img 
                   src="https://images.pexels.com/photos/3184291/pexels-photo-3184291.jpeg?auto=compress&cs=tinysrgb&w=500&h=500&fit=crop" 
                   alt="Person practicing language with TalkBuddy" 
@@ -367,10 +373,10 @@ function App() {
                 />
                 <div className="space-y-3">
                   <div className="flex items-center space-x-2">
-                    <div className="w-3 h-3 bg-orange-400 rounded-full animate-pulse"></div>
+                    <div className="w-3 h-3 bg-primary-400 rounded-full animate-pulse"></div>
                     <span className="text-sm text-gray-600">AI Language Partner Active</span>
                   </div>
-                  <div className="bg-orange-100 rounded-lg p-3 border border-orange-200">
+                  <div className="bg-primary-100 rounded-lg p-3 border border-primary-200">
                     <p className="text-sm text-gray-600">"Let's practice ordering at a restaurant. I'll be the waiter, and you're the customer..."</p>
                   </div>
                 </div>
@@ -381,7 +387,7 @@ function App() {
       </section>
 
       {/* Social Proof */}
-      <section className="py-20 bg-amber-50/95 backdrop-blur-sm border-y border-orange-200/30 shadow-sm scroll-animate">
+      <section className="py-20 bg-secondary-50/95 backdrop-blur-sm border-y border-primary-200/30 shadow-sm scroll-animate">
         <div className="max-w-7xl mx-auto px-2 sm:px-4 lg:px-6">
           <div className="text-center mb-12">
             <h2 className="text-3xl font-bold text-gray-900 mb-4">
@@ -394,10 +400,10 @@ function App() {
           
           <div className="grid grid-cols-2 lg:grid-cols-4 gap-8">
             <div className="text-center stagger-animate">
-              <div className="bg-orange-100 rounded-full w-16 h-16 flex items-center justify-center mx-auto mb-4 hover:bg-orange-200 hover:scale-110 transition-all duration-300 shadow-lg hover:shadow-xl">
-                <Users className="h-8 w-8 text-orange-600" />
+              <div className="bg-primary-100 rounded-full w-16 h-16 flex items-center justify-center mx-auto mb-4 hover:bg-primary-200 hover:scale-110 transition-all duration-300 shadow-lg hover:shadow-xl">
+                <Users className="h-8 w-8 text-primary-600" />
               </div>
-              <h3 className="text-xl font-semibold text-gray-900 mb-2 hover:text-orange-700 transition-colors duration-300">Working Professionals</h3>
+              <h3 className="text-xl font-semibold text-gray-900 mb-2 hover:text-primary-700 transition-colors duration-300">Working Professionals</h3>
               <p className="text-gray-600 text-sm hover:text-gray-700 transition-colors duration-300">Building confidence for meetings and presentations</p>
             </div>
             
@@ -429,7 +435,7 @@ function App() {
       </section>
 
       {/* Benefits Section */}
-      <section id="benefits" className="py-20 relative bg-gradient-to-br from-amber-100 to-orange-100 scroll-animate" style={{ marginTop: '0', paddingTop: '5rem' }}>
+      <section id="benefits" className="py-20 relative bg-gradient-to-br from-secondary-100 to-primary-100 scroll-animate" style={{ marginTop: '0', paddingTop: '5rem' }}>
         <div className="absolute inset-0 opacity-5 pointer-events-none">
           <div className="absolute inset-0" style={{
             backgroundImage: `url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23f97316' fill-opacity='0.1'%3E%3Ccircle cx='30' cy='30' r='2'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`,
@@ -451,10 +457,10 @@ function App() {
               return (
                 <div 
                   key={index}
-                  className="bg-orange-50/95 backdrop-blur-sm rounded-xl p-6 shadow-lg hover:shadow-xl transform hover:-translate-y-2 transition-all duration-300 border border-orange-300 hover:border-orange-400 group hover:bg-orange-100/90 stagger-animate"
+                  className="bg-primary-50/95 backdrop-blur-sm rounded-xl p-6 shadow-lg hover:shadow-xl transform hover:-translate-y-2 transition-all duration-300 border border-primary-300 hover:border-primary-400 group hover:bg-primary-100/90 stagger-animate"
                 >
                   <div className="mb-4">
-                    <Icon className="h-10 w-10 text-orange-600 mb-3 group-hover:text-orange-700 transition-colors duration-300" />
+                    <Icon className="h-10 w-10 text-primary-600 mb-3 group-hover:text-primary-700 transition-colors duration-300" />
                     <h3 className="text-xl font-semibold text-gray-900 mb-2 group-hover:text-gray-900 transition-colors duration-300">
                       {benefit.title}
                     </h3>
@@ -470,7 +476,7 @@ function App() {
       </section>
 
       {/* How It Works */}
-      <section id="how-it-works" className="py-20 bg-amber-50/95 backdrop-blur-sm relative scroll-animate">
+      <section id="how-it-works" className="py-20 bg-secondary-50/95 backdrop-blur-sm relative scroll-animate">
         <div className="absolute inset-0 opacity-5 pointer-events-none">
           <div className="absolute inset-0" style={{
             backgroundImage: `url("data:image/svg+xml,%3Csvg width='40' height='40' viewBox='0 0 40 40' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='%23f97316' fill-opacity='0.1' fill-rule='evenodd'%3E%3Cpath d='m0 40l40-40h-40v40zm40 0v-40h-40l40 40z'/%3E%3C/g%3E%3C/svg%3E")`,
@@ -490,16 +496,16 @@ function App() {
             {steps.map((step, index) => (
               <div 
                 key={index}
-                className="bg-orange-50/95 backdrop-blur-sm rounded-xl p-6 shadow-lg hover:shadow-xl transform hover:-translate-y-2 transition-all duration-300 border border-orange-300 hover:border-orange-400 group hover:bg-orange-100/90 stagger-animate"
+                className="bg-primary-50/95 backdrop-blur-sm rounded-xl p-6 shadow-lg hover:shadow-xl transform hover:-translate-y-2 transition-all duration-300 border border-primary-300 hover:border-primary-400 group hover:bg-primary-100/90 stagger-animate"
               >
                 <div className="flex flex-col lg:flex-row items-center gap-8">
                   <div className="flex-shrink-0">
-                    <div className="w-16 h-16 bg-orange-600 text-white rounded-full flex items-center justify-center text-2xl font-bold group-hover:scale-110 group-hover:bg-orange-700 transition-all duration-300">
+                    <div className="w-16 h-16 bg-primary-600 text-white rounded-full flex items-center justify-center text-2xl font-bold group-hover:scale-110 group-hover:bg-primary-700 transition-all duration-300">
                       {step.number}
                     </div>
                   </div>
                   <div className="flex-1 text-center lg:text-left">
-                    <h3 className="text-2xl font-semibold text-gray-900 mb-2 group-hover:text-orange-700 transition-colors duration-300">
+                    <h3 className="text-2xl font-semibold text-gray-900 mb-2 group-hover:text-primary-700 transition-colors duration-300">
                       {step.title}
                     </h3>
                     <p className="text-gray-600 text-lg leading-relaxed group-hover:text-gray-700 transition-colors duration-300">
@@ -514,7 +520,7 @@ function App() {
       </section>
 
       {/* Testimonials */}
-      <section id="testimonials" className="py-20 bg-gradient-to-b from-amber-100 to-orange-100 relative scroll-animate">
+      <section id="testimonials" className="py-20 bg-gradient-to-b from-secondary-100 to-primary-100 relative scroll-animate">
         <div className="absolute inset-0 opacity-5 pointer-events-none">
           <div className="absolute inset-0" style={{
             backgroundImage: `url("data:image/svg+xml,%3Csvg width='80' height='80' viewBox='0 0 80 80' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23f97316' fill-opacity='0.1'%3E%3Cpath d='M0 0h40v40H0V0zm40 40h40v40H40V40z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`,
@@ -537,7 +543,7 @@ function App() {
             >
               {testimonials.map((testimonial, index) => (
                 <div key={index} className="w-full flex-shrink-0 px-4">
-                  <div className="bg-orange-50/95 backdrop-blur-sm rounded-xl p-8 shadow-lg max-w-2xl mx-auto border border-orange-300">
+                  <div className="bg-primary-50/95 backdrop-blur-sm rounded-xl p-8 shadow-lg max-w-2xl mx-auto border border-primary-300">
                     <div className="flex mb-4">
                       {[...Array(testimonial.rating)].map((_, i) => (
                         <Star key={i} className="h-5 w-5 text-yellow-400 fill-current" />
@@ -565,7 +571,7 @@ function App() {
                   key={index}
                   onClick={() => setCurrentTestimonial(index)}
                   className={`w-3 h-3 rounded-full transition-colors duration-200 ${
-                    index === currentTestimonial ? 'bg-orange-600' : 'bg-orange-200'
+                    index === currentTestimonial ? 'bg-primary-600' : 'bg-primary-200'
                   }`}
                 />
               ))}
@@ -575,7 +581,7 @@ function App() {
       </section>
 
       {/* FAQ Section */}
-      <section id="faq" className="py-20 bg-amber-50/95 backdrop-blur-sm relative scroll-animate">
+      <section id="faq" className="py-20 bg-secondary-50/95 backdrop-blur-sm relative scroll-animate">
         <div className="absolute inset-0 opacity-5 pointer-events-none">
           <div className="absolute inset-0" style={{
             backgroundImage: `url("data:image/svg+xml,%3Csvg width='20' height='20' viewBox='0 0 20 20' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='%23f97316' fill-opacity='0.1' fill-rule='evenodd'%3E%3Ccircle cx='3' cy='3' r='3'/%3E%3Ccircle cx='13' cy='13' r='3'/%3E%3C/g%3E%3C/svg%3E")`,
@@ -593,10 +599,10 @@ function App() {
 
           <div className="space-y-4">
             {faqs.map((faq, index) => (
-              <div key={index} className="bg-orange-50/95 backdrop-blur-sm rounded-lg shadow-md border border-orange-300 hover:border-orange-400 transition-colors duration-200">
+              <div key={index} className="bg-primary-50/95 backdrop-blur-sm rounded-lg shadow-md border border-primary-300 hover:border-primary-400 transition-colors duration-200">
                 <button
                   onClick={() => toggleFAQ(index)}
-                  className="w-full px-6 py-4 text-left flex justify-between items-center hover:bg-orange-100/80 transition-colors duration-200"
+                  className="w-full px-6 py-4 text-left flex justify-between items-center hover:bg-primary-100/80 transition-colors duration-200"
                 >
                   <span className="font-semibold text-gray-900 pr-4">
                     {faq.question}
@@ -632,7 +638,7 @@ function App() {
             </p>
             <button 
               onClick={() => handleAuthModal('signup')}
-              className="px-8 py-4 bg-orange-600 text-white rounded-lg hover:bg-orange-700 transform hover:scale-105 transition-all duration-200 font-medium text-lg shadow-lg"
+              className="px-8 py-4 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transform hover:scale-105 transition-all duration-200 font-medium text-lg shadow-lg"
             >
               Try Your First Conversation
             </button>
@@ -642,7 +648,7 @@ function App() {
             <div className="grid md:grid-cols-4 gap-8">
               <div className="md:col-span-2">
                 <div className="flex items-center space-x-2 mb-4">
-                  <Mic className="h-8 w-8 text-orange-400" />
+                  <Mic className="h-8 w-8 text-primary-400" />
                   <span className="text-2xl font-bold">TalkBuddy</span>
                 </div>
                 <p className="text-gray-400 leading-relaxed">

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -125,7 +125,7 @@ export default function AuthModal({ isOpen, onClose, initialMode = 'login', show
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
-      <div className="bg-orange-50 rounded-xl max-w-md w-full p-6 relative border border-orange-200 shadow-2xl">
+      <div className="bg-primary-50 rounded-xl max-w-md w-full p-6 relative border border-primary-200 shadow-2xl">
         <button
           onClick={onClose}
           className="absolute top-4 right-4 text-gray-400 hover:text-gray-600"
@@ -171,7 +171,7 @@ export default function AuthModal({ isOpen, onClose, initialMode = 'login', show
                     name="firstName"
                     value={formData.firstName}
                     onChange={handleInputChange}
-                    className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+                    className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
                     placeholder="John"
                     required
                   />
@@ -188,7 +188,7 @@ export default function AuthModal({ isOpen, onClose, initialMode = 'login', show
                     name="lastName"
                     value={formData.lastName}
                     onChange={handleInputChange}
-                    className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+                    className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
                     placeholder="Doe"
                     required
                   />
@@ -208,7 +208,7 @@ export default function AuthModal({ isOpen, onClose, initialMode = 'login', show
                 name="email"
                 value={formData.email}
                 onChange={handleInputChange}
-                className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+                className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
                 placeholder="your@email.com"
                 required
               />
@@ -227,7 +227,7 @@ export default function AuthModal({ isOpen, onClose, initialMode = 'login', show
                   name="password"
                   value={formData.password}
                   onChange={handleInputChange}
-                  className="w-full pl-10 pr-12 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+                  className="w-full pl-10 pr-12 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
                   placeholder="••••••••"
                   required
                   minLength={6}
@@ -246,7 +246,7 @@ export default function AuthModal({ isOpen, onClose, initialMode = 'login', show
           <button
             type="submit"
             disabled={loading}
-            className="w-full py-2 px-4 bg-orange-600 text-white rounded-lg hover:bg-orange-700 focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center justify-center"
+            className="w-full py-2 px-4 bg-primary-600 text-white rounded-lg hover:bg-primary-700 focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center justify-center"
           >
             {loading ? (
               <Loader2 className="h-5 w-5 animate-spin" />
@@ -261,7 +261,7 @@ export default function AuthModal({ isOpen, onClose, initialMode = 'login', show
             <div className="space-y-2">
               <button
                 onClick={() => switchMode('signup')}
-                className="text-orange-600 hover:text-orange-700 font-medium"
+                className="text-primary-600 hover:text-primary-700 font-medium"
               >
                 Don't have an account? Sign up
               </button>
@@ -277,14 +277,14 @@ export default function AuthModal({ isOpen, onClose, initialMode = 'login', show
           ) : mode === 'signup' ? (
             <button
               onClick={() => switchMode('login')}
-              className="text-orange-600 hover:text-orange-700 font-medium"
+              className="text-primary-600 hover:text-primary-700 font-medium"
             >
               Already have an account? Sign in
             </button>
           ) : (
             <button
               onClick={() => switchMode('login')}
-              className="text-orange-600 hover:text-orange-700 font-medium"
+              className="text-primary-600 hover:text-primary-700 font-medium"
             >
               Back to sign in
             </button>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Mic,
   LogOut,
@@ -17,6 +17,10 @@ interface DashboardProps {
 }
 
 export default function Dashboard({ user }: DashboardProps) {
+  const [loaded, setLoaded] = useState(false);
+  useEffect(() => {
+    setLoaded(true);
+  }, []);
   const handleLogout = async () => {
     await supabase.auth.signOut();
   };
@@ -26,7 +30,7 @@ export default function Dashboard({ user }: DashboardProps) {
   const mockStats = [
     { label: 'Conversations', value: '12', icon: MessageCircle, color: 'text-blue-600' },
     { label: 'Speaking Time', value: '2.5h', icon: Clock, color: 'text-green-600' },
-    { label: 'Streak', value: '7 days', icon: Target, color: 'text-orange-600' },
+    { label: 'Streak', value: '7 days', icon: Target, color: 'text-primary-600' },
     { label: 'Level', value: 'B1', icon: Award, color: 'text-purple-600' }
   ];
 
@@ -38,13 +42,13 @@ export default function Dashboard({ user }: DashboardProps) {
   ];
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-amber-100 to-orange-100">
+    <div className={`min-h-screen bg-gradient-to-br from-secondary-100 to-primary-100 transition-opacity duration-700 ${loaded ? 'opacity-100' : 'opacity-0'}`}> 
       {/* Header */}
-      <header className="bg-orange-50/95 backdrop-blur-sm border-b border-amber-300">
+      <header className="bg-primary-50/95 backdrop-blur-sm border-b border-secondary-300">
         <div className="max-w-7xl mx-auto px-2 sm:px-4 lg:px-6">
           <div className="flex justify-between items-center py-4">
             <div className="flex items-center space-x-2">
-              <Mic className="h-8 w-8 text-orange-600" />
+              <Mic className="h-8 w-8 text-primary-600" />
               <span className="text-2xl font-bold text-gray-900">TalkBuddy</span>
             </div>
             
@@ -79,7 +83,7 @@ export default function Dashboard({ user }: DashboardProps) {
           {mockStats.map((stat, index) => {
             const Icon = stat.icon;
             return (
-              <div key={index} className="bg-orange-50 rounded-xl p-6 shadow-lg border border-orange-300">
+              <div key={index} className="bg-primary-50 rounded-xl p-6 shadow-lg border border-primary-300">
                 <div className="flex items-center justify-between mb-2">
                   <Icon className={`h-6 w-6 ${stat.color}`} />
                 </div>
@@ -98,14 +102,14 @@ export default function Dashboard({ user }: DashboardProps) {
         <div className="grid lg:grid-cols-3 gap-8">
           {/* Quick Start */}
           <div className="lg:col-span-2">
-            <div className="bg-orange-50 rounded-xl p-6 shadow-lg border border-orange-300 mb-6">
+            <div className="bg-primary-50 rounded-xl p-6 shadow-lg border border-primary-300 mb-6">
               <h2 className="text-xl font-semibold text-gray-900 mb-4">
                 Quick Start
               </h2>
               <div className="grid md:grid-cols-2 gap-4">
-                <button className="p-4 bg-orange-100 hover:bg-orange-200 rounded-lg border border-orange-300 transition-colors text-left">
+                <button className="p-4 bg-primary-100 hover:bg-primary-200 rounded-lg border border-primary-300 transition-colors text-left">
                   <div className="flex items-center space-x-3 mb-2">
-                    <Play className="h-6 w-6 text-orange-600" />
+                    <Play className="h-6 w-6 text-primary-600" />
                     <span className="font-medium text-gray-900">Start New Conversation</span>
                   </div>
                   <p className="text-sm text-gray-600">
@@ -126,7 +130,7 @@ export default function Dashboard({ user }: DashboardProps) {
             </div>
 
             {/* Recent Topics */}
-            <div className="bg-orange-50 rounded-xl p-6 shadow-lg border border-orange-300">
+            <div className="bg-primary-50 rounded-xl p-6 shadow-lg border border-primary-300">
               <h2 className="text-xl font-semibold text-gray-900 mb-4">
                 Recent Topics
               </h2>
@@ -142,7 +146,7 @@ export default function Dashboard({ user }: DashboardProps) {
                         <div className="text-sm text-gray-600">{topic.duration}</div>
                       </div>
                     </div>
-                    <button className="text-orange-600 hover:text-orange-700 font-medium text-sm">
+                    <button className="text-primary-600 hover:text-primary-700 font-medium text-sm">
                       {topic.completed ? 'Review' : 'Continue'}
                     </button>
                   </div>
@@ -154,7 +158,7 @@ export default function Dashboard({ user }: DashboardProps) {
           {/* Sidebar */}
           <div className="space-y-6">
             {/* Progress Chart */}
-            <div className="bg-orange-50 rounded-xl p-6 shadow-lg border border-orange-300">
+            <div className="bg-primary-50 rounded-xl p-6 shadow-lg border border-primary-300">
               <h3 className="text-lg font-semibold text-gray-900 mb-4">
                 Weekly Progress
               </h3>
@@ -164,7 +168,7 @@ export default function Dashboard({ user }: DashboardProps) {
                   <span className="font-medium">2.5h / 5h</span>
                 </div>
                 <div className="w-full bg-gray-200 rounded-full h-2">
-                  <div className="bg-orange-600 h-2 rounded-full" style={{ width: '50%' }}></div>
+                  <div className="bg-primary-600 h-2 rounded-full" style={{ width: '50%' }}></div>
                 </div>
               </div>
               
@@ -180,7 +184,7 @@ export default function Dashboard({ user }: DashboardProps) {
             </div>
 
             {/* Achievements */}
-            <div className="bg-orange-50 rounded-xl p-6 shadow-lg border border-orange-300">
+            <div className="bg-primary-50 rounded-xl p-6 shadow-lg border border-primary-300">
               <h3 className="text-lg font-semibold text-gray-900 mb-4">
                 Recent Achievements
               </h3>
@@ -208,14 +212,14 @@ export default function Dashboard({ user }: DashboardProps) {
             </div>
 
             {/* Next Session */}
-            <div className="bg-gradient-to-r from-orange-500 to-orange-600 rounded-xl p-6 text-white">
+            <div className="bg-gradient-to-r from-primary-500 to-primary-600 rounded-xl p-6 text-white">
               <h3 className="text-lg font-semibold mb-2">
                 Ready for your next session?
               </h3>
-              <p className="text-orange-100 text-sm mb-4">
+              <p className="text-primary-100 text-sm mb-4">
                 Continue building your confidence with personalized conversations.
               </p>
-              <button className="w-full py-2 bg-white text-orange-600 rounded-lg hover:bg-orange-50 transition-colors font-medium">
+              <button className="w-full py-2 bg-white text-primary-600 rounded-lg hover:bg-primary-50 transition-colors font-medium">
                 Start Speaking
               </button>
             </div>

--- a/src/index.css
+++ b/src/index.css
@@ -37,13 +37,13 @@
 }
 
 .subtle-bg-shift {
-  background: linear-gradient(45deg, #fed7aa 0%, #fdba74 50%, #fed7aa 100%);
+  background: linear-gradient(45deg, #eef2ff 0%, #d1fae5 50%, #eef2ff 100%);
   background-size: 200% 200%;
   animation: subtleShift 20s ease-in-out infinite;
 }
 
 .subtle-bg-shift-dark {
-  background: linear-gradient(45deg, #fed7aa 0%, #fdba74 50%, #fed7aa 100%);
+  background: linear-gradient(45deg, #c7d2fe 0%, #a7f3d0 50%, #c7d2fe 100%);
   background-size: 200% 200%;
   animation: subtleShift 20s ease-in-out infinite;
 }
@@ -58,12 +58,12 @@
 }
 
 @keyframes pulseGlow {
-  0%, 100% { 
-    box-shadow: 0 0 20px rgba(251, 146, 60, 0.3);
+  0%, 100% {
+    box-shadow: 0 0 20px rgba(99, 102, 241, 0.3);
     transform: scale(1);
   }
-  50% { 
-    box-shadow: 0 0 30px rgba(251, 146, 60, 0.5);
+  50% {
+    box-shadow: 0 0 30px rgba(99, 102, 241, 0.5);
     transform: scale(1.02);
   }
 }
@@ -80,12 +80,12 @@
 }
 
 @keyframes softGlow {
-  0%, 100% { 
-    box-shadow: 0 0 40px rgba(251, 146, 60, 0.25);
+  0%, 100% {
+    box-shadow: 0 0 40px rgba(99, 102, 241, 0.25);
     opacity: 0.4;
   }
-  50% { 
-    box-shadow: 0 0 70px rgba(251, 146, 60, 0.4);
+  50% {
+    box-shadow: 0 0 70px rgba(99, 102, 241, 0.4);
     opacity: 0.6;
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,20 +1,15 @@
+import colors from 'tailwindcss/colors';
+
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {
       colors: {
-        'cream': {
-          50: '#fefdf8',
-          100: '#fdf9f0',
-        },
-        'amber': {
-          25: '#fefcf3',
-        },
-        'orange': {
-          25: '#fefaf6',
-        }
-      }
+        primary: colors.indigo,
+        secondary: colors.emerald,
+        accent: colors.amber,
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- revamp color scheme using Tailwind primary/secondary/accent palette
- add subtle gradients and glow animations for a polished look
- introduce fade-in page transitions for landing and dashboard views

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68975b39ead0832a8e25959ab8a76c6f