### PR TITLE
Remove mismatch message for practice prompt mismatch

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -3965,14 +3965,6 @@ Keep it short and helpful. Don't repeat the same phrase multiple times.`
                   </div>
                 )}
 
-                {message.role === 'user' && messageStatus[message.id] === 'mismatch' && (
-                  <div className="flex justify-end mt-2">
-                    <div className="bg-red-50 text-red-600 px-3 py-1 rounded-lg text-xs font-medium">
-                      English detected – check the practice prompt.
-                    </div>
-                  </div>
-                )}
-
                 {message.role === 'user' && messageStatus[message.id] === 'error' && (
                   <div className="flex justify-end mt-2">
                     <div className="bg-red-50 text-red-600 px-3 py-1 rounded-lg text-xs font-medium">


### PR DESCRIPTION
## Summary
- remove the hard-coded mismatch alert that told users to check the practice prompt

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68daeca197d8832a9dd0a70d16029a1f